### PR TITLE
Switch build-backend to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,5 +55,5 @@ commands =
 """
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
poetry-core is the lightweight counterpart of poetry that is intended to be used as a build-backend. Unlike poetry, it does not require installing all the dependencies of the package manager, making the builds much faster. The generated artifacts are the same.